### PR TITLE
chore!: drop support for Typo3 core-cms V11

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
       - master
+      - default
 
 permissions:
   contents: write
@@ -17,4 +18,3 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         with:
           release-type: php
-          package-name: release-please-action


### PR DESCRIPTION
BREAKING CHANGE: use build with Typo3 core-cms to v12 from now on